### PR TITLE
Remove white space

### DIFF
--- a/oscap_report/cli.py
+++ b/oscap_report/cli.py
@@ -90,7 +90,7 @@ class CommandLineAPI():
             choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
             help=(
                 "creates LOG_FILE file with log information depending on LOG_LEVEL."
-                "\n{}").format(LOG_LEVES_DESCRIPTION)
+                f"\n{LOG_LEVES_DESCRIPTION}")
         )
         parser.add_argument(
             "-f",

--- a/oscap_report/html_report/report_generator.py
+++ b/oscap_report/html_report/report_generator.py
@@ -1,3 +1,4 @@
+import re
 from io import BytesIO
 from pathlib import Path
 
@@ -9,7 +10,11 @@ class ReportGenerator():
         self.report = parser.parse_report()
         self.file_loader = FileSystemLoader(str(Path(__file__).parent / "templates"))
         self.env = Environment(loader=self.file_loader)
+        self.env.trim_blocks = True
+        self.env.lstrip_blocks = True
 
     def generate_html_report(self):
         template = self.env.get_template("template_report.html")
-        return BytesIO(template.render(report=self.report).encode())
+        html_report = template.render(report=self.report)
+        minified_html_report = re.sub(r'>\s+<', '><', html_report)
+        return BytesIO(minified_html_report.encode())

--- a/oscap_report/html_report/templates/evaluation_characteristics.html
+++ b/oscap_report/html_report/templates/evaluation_characteristics.html
@@ -16,11 +16,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Profile ID:</div>
                             <div class="pf-c-data-list__cell">
-                                Profile ID:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.profile_name }}
+                                {{- report.profile_name -}}
                             </div>
                         </div>
                     </div>
@@ -29,11 +27,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Evaluation target:</div>
                             <div class="pf-c-data-list__cell">
-                                Evaluation target:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.target }}
+                                {{- report.target -}}
                             </div>
                         </div>
                     </div>
@@ -42,11 +38,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Performed by:</div>
                             <div class="pf-c-data-list__cell">
-                                Performed by:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.identity }}
+                                {{- report.identity -}}
                             </div>
                         </div>
                     </div>
@@ -55,11 +49,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Scanner:</div>
                             <div class="pf-c-data-list__cell">
-                                Scanner:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.scanner }} {{ report.scanner_version }}
+                                {{- report.scanner -}} {{- report.scanner_version -}}
                             </div>
                         </div>
                     </div>
@@ -68,11 +60,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Benchmark ID:</div>
                             <div class="pf-c-data-list__cell">
-                                Benchmark ID:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.benchmark_id }}
+                                {{- report.benchmark_id -}}
                             </div>
                         </div>
                     </div>
@@ -81,11 +71,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Benchmark url:</div>
                             <div class="pf-c-data-list__cell">
-                                Benchmark url:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.benchmark_url }}
+                                {{- report.benchmark_url -}}
                             </div>
                         </div>
                     </div>
@@ -94,11 +82,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Benchmark version:</div>
                             <div class="pf-c-data-list__cell">
-                                Benchmark version:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.benchmark_version }}
+                                {{- report.benchmark_version -}}
                             </div>
                         </div>
                     </div>
@@ -107,11 +93,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Started at:</div>
                             <div class="pf-c-data-list__cell">
-                                Started at:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.start_time }}
+                                {{- report.start_time -}}
                             </div>
                         </div>
                     </div>
@@ -120,11 +104,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Finished at:</div>
                             <div class="pf-c-data-list__cell">
-                                Finished at:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.end_time }}
+                                {{- report.end_time -}}
                             </div>
                         </div>
                     </div>
@@ -133,11 +115,9 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
+                            <div class="pf-c-data-list__cell">Test system:</div>
                             <div class="pf-c-data-list__cell">
-                                Test system:
-                            </div>
-                            <div class="pf-c-data-list__cell">
-                                {{ report.test_system }}
+                                {{- report.test_system -}}
                             </div>
                         </div>
                     </div>

--- a/oscap_report/html_report/templates/oval_graph.html
+++ b/oscap_report/html_report/templates/oval_graph.html
@@ -32,7 +32,7 @@
                         </span>
                         <span class="pf-c-label {{color}}">
                             <span class="pf-c-label__content">
-                                {{ node.tag }}
+                                {{- node.tag -}}
                             </span>
                         </span>
                         <span class="pf-c-label {{color}}">
@@ -40,7 +40,7 @@
                                 <span class="pf-c-label__icon">
                                     <i class="fas fa-fw {{ icon }}" aria-hidden="true"></i>
                                 </span>
-                                {{ node.value }}
+                                {{- node.value -}}
                             </span>
                         </span>
                     </span>
@@ -88,16 +88,16 @@
                             </span>
                         {%- endif %}
                         <span style="color: var({{ COLOR_TRANSLATION[color] }});">
-                            {% if not node.negation -%}    
+                            {% if not node.negation -%}
                                 <span class="pf-c-label__icon">
                                     <i class="fas fa-fw {{ icon }}" aria-hidden="true"></i>
                                 </span>
                             {%- endif %}
-                            <b>{{ node.node_type }}</b>
+                            <b>{{- node.node_type -}}</b>
                         </span>
                         <span class="pf-c-label {{color}}">
                             <span class="pf-c-label__content">
-                                {{ node.tag }}
+                                {{- node.tag -}}
                             </span>
                         </span>
                         <span class="pf-c-label {{color}}">
@@ -105,7 +105,7 @@
                                 <span class="pf-c-label__icon">
                                     <i class="fas fa-fw {{ icon }}" aria-hidden="true"></i>
                                 </span>
-                                {{ node.value }}
+                                {{- node.value -}}
                             </span>
                         </span>
                     </span>
@@ -163,7 +163,7 @@
     </div>
     <div class="pf-c-tree-view pf-m-guides">
         <ul class="pf-c-tree-view__list" role="tree">
-                {{ render_OVAL_tree(rule.oval_tree) }}
+                {{- render_OVAL_tree(rule.oval_tree) -}}
         </ul>
     </div>
 {% else %}
@@ -174,7 +174,7 @@
     <p class="pf-c-alert__title">
         <span class="pf-screen-reader">Warning alert:</span>
         There is no OVAL graph.<br>
-        {{ rule.message }}
+        {{- rule.message -}}
     </p>
 </div>
 {%- endif %}

--- a/oscap_report/html_report/templates/rule_detail.html
+++ b/oscap_report/html_report/templates/rule_detail.html
@@ -1,10 +1,7 @@
 <div class="pf-c-expandable-section__content">
     <table class="pf-c-table pf-m-grid-md" role="grid">
         <thead>
-            <tr role="row">
-                <th role="columnheader" scope="col"></th>
-                <th role="columnheader" scope="col"></th>
-            </tr>
+            <tr role="row"></tr>
         </thead>
         <tbody role="rowgroup">
             <tr role="row">

--- a/oscap_report/html_report/templates/rule_detail.html
+++ b/oscap_report/html_report/templates/rule_detail.html
@@ -20,7 +20,7 @@
                             <span class="pf-c-label__icon">
                                 <i class="fas fa-fw fa-check" aria-hidden="true"></i>
                             </span>
-                            {{ rule.result }}
+                            {{ rule.result -}}
                         </span>
                     </span>
                     {% elif rule.result == "fail"%}
@@ -29,7 +29,7 @@
                             <span class="pf-c-label__icon">
                                 <i class="fas fa-fw fa-times" aria-hidden="true"></i>
                             </span>
-                            {{ rule.result }}
+                            {{- rule.result -}}
                         </span>
                     </span>
                     {% else %}
@@ -38,7 +38,7 @@
                             <span class="pf-c-label__icon">
                                 <i class="fas fa-fw fa-question-circle" aria-hidden="true"></i>
                             </span>
-                        {{ rule.result }}
+                        {{- rule.result -}}
                         </span>
                     </span>
                     {% endif %}
@@ -87,10 +87,10 @@
                 <td role="cell">Identifiers:</td>
                 <td role="cell">
                     <div>
-                        {% for identifier in rule.identifiers %}
+                        {% for identifier in rule.identifiers -%}
                         <a href="{{ identifier.href }}">{{ identifier.text }}</a>
-                        {{ ", " if not loop.last else "" }}
-                        {% endfor %}
+                        {{- ", " if not loop.last else "" -}}
+                        {%- endfor %}
                     </div>
                 </td>
             </tr>
@@ -100,10 +100,10 @@
                 <td role="cell">References:</td>
                 <td role="cell">
                     <div>
-                        {% for reference in rule.references %}
+                        {% for reference in rule.references -%}
                         <a href="{{ reference.href }}">{{ reference.text }}</a>
-                        {{ ", " if not loop.last else "" }}
-                        {% endfor %}
+                        {{- ", " if not loop.last else "" -}}
+                        {%- endfor %}
                     </div>
                 </td>
             </tr>
@@ -129,7 +129,7 @@
                         </div>
                         <p class="pf-c-alert__title">
                             <span class="pf-screen-reader">Warning alert:</span>
-                            {{ warning }}
+                            {{- warning -}}
                         </p>
                     </div>
                     <br>

--- a/oscap_report/html_report/templates/rule_results.html
+++ b/oscap_report/html_report/templates/rule_results.html
@@ -1,17 +1,13 @@
 <div class="progress" style="height: 20px;">
     {% if 0 != rule_result_stats.pass %}
-    <div class="progress-bar" role="progressbar"
-        style="width:{{ rule_result_stats.pass_percent }}%;background-color: #3E8635;">{{ rule_result_stats.pass }} Pass
+    <div class="progress-bar" role="progressbar" style="width:{{ rule_result_stats.pass_percent }}%;background-color: #3E8635;">{{ rule_result_stats.pass }} Pass
     </div>
     {% endif %}
     {% if 0 != rule_result_stats.fail %}
-    <div class="progress-bar" role="progressbar"
-        style="width:{{ rule_result_stats.fail_percent }}%;background-color: #C9190B;">{{ rule_result_stats.fail }} Fail
-    </div>
+    <div class="progress-bar" role="progressbar" style="width:{{ rule_result_stats.fail_percent }}%;background-color: #C9190B;">{{ rule_result_stats.fail }} Fail</div>
     {% endif %}
     {% if 0 != rule_result_stats.other %}
     <div class="progress-bar" role="progressbar"
-        style="width:{{ rule_result_stats.other_percent }}%;background-color: #F0AB00;">{{ rule_result_stats.other }}
-        Other</div>
+        style="width:{{ rule_result_stats.other_percent }}%;background-color: #F0AB00;">{{ rule_result_stats.other }} Other</div>
     {% endif %}
 </div>

--- a/oscap_report/html_report/templates/rules_overview.html
+++ b/oscap_report/html_report/templates/rules_overview.html
@@ -59,7 +59,7 @@
                         <span class="pf-c-label__icon">
                             <i class="fas fa-fw fa-check" aria-hidden="true"></i>
                         </span>
-                        {{ rule.result }}
+                        {{- rule.result -}}
                     </span>
                 </span>
                 {% elif rule.result == "fail"%}
@@ -68,7 +68,7 @@
                         <span class="pf-c-label__icon">
                             <i class="fas fa-fw fa-times" aria-hidden="true"></i>
                         </span>
-                        {{ rule.result }}
+                        {{- rule.result -}}
                     </span>
                 </span>
                 {% else %}
@@ -77,7 +77,7 @@
                         <span class="pf-c-label__icon">
                             <i class="fas fa-fw fa-question-circle" aria-hidden="true"></i>
                         </span>
-                    {{ rule.result }}
+                    {{- rule.result -}}
                     </span>
                 </span>
                 {% endif %}

--- a/oscap_report/html_report/templates/rules_overview.html
+++ b/oscap_report/html_report/templates/rules_overview.html
@@ -17,6 +17,7 @@
         </tr>
     </thead>
     {% for rule_id, rule in report.rules.items() %}
+    {%- if rule.result != "notselected" -%}
     <tbody class="pf-m-expanded" role="rowgroup" id="rule" title="{{ rule.title }}" rule-id="{{ rule.rule_id }}">
         <tr role="row">
             <td class="pf-c-table__toggle" role="cell">
@@ -92,5 +93,6 @@
             </td>
         </tr>
     </tbody>
+    {% endif %}
     {% endfor %}
 </table>

--- a/oscap_report/scap_results_parser/oval_definition_parser/info_of_test_parser.py
+++ b/oscap_report/scap_results_parser/oval_definition_parser/info_of_test_parser.py
@@ -127,7 +127,7 @@ class InfoOfTest:
     @staticmethod
     def _complete_message(item, var_id):
         if len(item.text) == MAX_MESSAGE_LEN and var_id[:item.text.find('(')] in var_id:
-            return "{}{})".format(item.text[:item.text.find('(') + 1], var_id)
+            return f"{item.text[:item.text.find('(') + 1]}{var_id})"
         return item.text
 
     @staticmethod

--- a/oscap_report/scap_results_parser/scap_results_parser.py
+++ b/oscap_report/scap_results_parser/scap_results_parser.py
@@ -196,7 +196,7 @@ class SCAPResultsParser():
             result = "unknown"
 
         merged_oval_tree = OvalNode(
-            node_id="{} and {}".format(rule.oval_tree.node_id, rule.platform),
+            node_id=f"{rule.oval_tree.node_id} and {rule.platform}",
             node_type="AND",
             value=result,
             tag="Rule definition and CPE definition",


### PR DESCRIPTION
This PR removes white spaces and not selected rules from the generated reports. The size of the generated report was reduced by up to 30%.