### PR TITLE
Fix details in HTML report

### DIFF
--- a/oscap_report/html_report/templates/base_report.html
+++ b/oscap_report/html_report/templates/base_report.html
@@ -16,10 +16,21 @@
             box-shadow: 0 0 8px 0 rgba(0, 0, 0, .1);
         }
 
-        .custom-col {
-            column-count: 2;
-            column-gap: 40px;
-            column-rule: 1px solid rgb(0, 0, 0);
+        .progress-bar {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            color: #fff;
+            text-align: center;
+            min-width: 10em;
+            height: 20px;
+        }
+
+        .progress {
+            display: flex;
+            height: 1rem;
+            font-size: .75rem;
+            background-color: #e9ecef;
         }
     </style>
     <script>

--- a/oscap_report/html_report/templates/base_report.html
+++ b/oscap_report/html_report/templates/base_report.html
@@ -27,13 +27,15 @@
     <script>
         // Search engine of rules
         $(document).ready(function () {
-            $("#input-search-rule").on("keyup", function () {
-                var value = $(this).val().toLowerCase();
-                $("#rule-table tbody#rule").hide().filter(function () {
-                    var is_matched_title = $(this).attr("title").toLowerCase().includes(value);
-                    var is_matched_rule_id = $(this).attr("rule-id").toLowerCase().includes(value);
-                    return is_matched_title || is_matched_rule_id;
-                }).show();
+            $("#input-search-rule").on('keypress',function(e) {
+                if(e.which == 13) {
+                    var value = $(this).val().toLowerCase();
+                    $("#rule-table tbody#rule").hide().filter(function () {
+                        var is_matched_title = $(this).attr("title").toLowerCase().includes(value);
+                        var is_matched_rule_id = $(this).attr("rule-id").toLowerCase().includes(value);
+                        return is_matched_title || is_matched_rule_id;
+                    }).show();
+                }
             });
         });
         function toggle_OVAL_operator(self) {

--- a/oscap_report/html_report/templates/base_report.html
+++ b/oscap_report/html_report/templates/base_report.html
@@ -5,8 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
-        integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
     <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly/patternfly.css" crossorigin="anonymous">
     <title>{% block title %}{% endblock %}</title>
     <style>
@@ -358,9 +356,5 @@
                 {% endblock %}
             </section>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj"
-        crossorigin="anonymous"></script>
 </body>
-
 </html>

--- a/oscap_report/html_report/templates/evaluation_characteristics.html
+++ b/oscap_report/html_report/templates/evaluation_characteristics.html
@@ -13,7 +13,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Profile ID:</div>
+                            <div class="pf-c-data-list__cell"><b>Profile ID:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.profile_name -}}
                             </div>
@@ -24,7 +24,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Evaluation target:</div>
+                            <div class="pf-c-data-list__cell"><b>Evaluation target:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.target -}}
                             </div>
@@ -35,7 +35,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Performed by:</div>
+                            <div class="pf-c-data-list__cell"><b>Performed by:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.identity -}}
                             </div>
@@ -46,7 +46,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Scanner:</div>
+                            <div class="pf-c-data-list__cell"><b>Scanner:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.scanner -}} {{- report.scanner_version -}}
                             </div>
@@ -57,7 +57,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Benchmark ID:</div>
+                            <div class="pf-c-data-list__cell"><b>Benchmark ID:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.benchmark_id -}}
                             </div>
@@ -68,7 +68,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Benchmark url:</div>
+                            <div class="pf-c-data-list__cell"><b>Benchmark url:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.benchmark_url -}}
                             </div>
@@ -79,7 +79,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Benchmark version:</div>
+                            <div class="pf-c-data-list__cell"><b>Benchmark version:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.benchmark_version -}}
                             </div>
@@ -90,7 +90,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Started at:</div>
+                            <div class="pf-c-data-list__cell"><b>Started at:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.start_time -}}
                             </div>
@@ -101,7 +101,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Finished at:</div>
+                            <div class="pf-c-data-list__cell"><b>Finished at:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.end_time -}}
                             </div>
@@ -112,7 +112,7 @@
                 <li class="pf-c-data-list__item">
                     <div class="pf-c-data-list__item-row">
                         <div class="pf-c-data-list__item-content">
-                            <div class="pf-c-data-list__cell">Test system:</div>
+                            <div class="pf-c-data-list__cell"><b>Test system:</b></div>
                             <div class="pf-c-data-list__cell">
                                 {{- report.test_system -}}
                             </div>

--- a/oscap_report/html_report/templates/oval_graph.html
+++ b/oscap_report/html_report/templates/oval_graph.html
@@ -32,7 +32,6 @@
     <p class="pf-c-alert__title">
         <span class="pf-screen-reader">Warning alert:</span>
         There is no OVAL graph.<br>
-        {{- rule.message -}}
     </p>
 </div>
 {%- endif %}

--- a/oscap_report/html_report/templates/rule_detail.html
+++ b/oscap_report/html_report/templates/rule_detail.html
@@ -5,11 +5,11 @@
         </thead>
         <tbody role="rowgroup">
             <tr role="row">
-                <td role="cell">Rule ID:</td>
+                <td role="cell"><b>Rule ID:</b></td>
                 <td role="cell">{{ rule.rule_id }}</td>
             </tr>
             <tr role="row">
-                <td role="cell">Result:</td>
+                <td role="cell"><b>Result:</b></td>
                 <td role="cell">
                     {% if rule.result == "pass" %}
                     <span class="pf-c-label pf-m-green">
@@ -42,7 +42,7 @@
                 </td>
             </tr>
             <tr role="row">
-                <td role="cell">Multi-check rule:</td>
+                <td role="cell"><b>Multi-check rule:</b></td>
                 {% if rule.multi_check %}
                     <td role="cell">yes</td>
                 {% else %}
@@ -50,15 +50,15 @@
                 {% endif %}
             </tr>
             <tr role="row">
-                <td role="cell">OVAL Definition ID:</td>
+                <td role="cell"><b>OVAL Definition ID:</b></td>
                 <td role="cell">{{ rule.oval_definition_id }}</td>
             </tr>
             <tr role="row">
-                <td role="cell">Time:</td>
+                <td role="cell"><b>Time:</b></td>
                 <td role="cell">{{ rule.time }}</td>
             </tr>
             <tr role="row">
-                <td role="cell">Severity:</td>
+                <td role="cell"><b>Severity:</b></td>
                 <td role="cell">
                     {% if rule.result != "pass" and rule.severity == "low" %}
                     <span class="pf-c-label pf-m-blue">
@@ -81,7 +81,7 @@
             </tr>
             {% if rule.identifiers %}
             <tr role="row">
-                <td role="cell">Identifiers:</td>
+                <td role="cell"><b>Identifiers:</b></td>
                 <td role="cell">
                     <div>
                         {% for identifier in rule.identifiers -%}
@@ -94,7 +94,7 @@
             {% endif %}
             {% if rule.references %}
             <tr role="row">
-                <td role="cell">References:</td>
+                <td role="cell"><b>References:</b></td>
                 <td role="cell">
                     <div>
                         {% for reference in rule.references -%}
@@ -106,18 +106,18 @@
             </tr>
             {% endif %}
             <tr role="row">
-                <td role="cell">Description:</td>
+                <td role="cell"><b>Description:</b></td>
                 <td role="cell">{{ rule.description }}</td>
             </tr>
             {% if rule.rationale %}
             <tr role="row">
-                <td role="cell">Rationale:</td>
+                <td role="cell"><b>Rationale:</b></td>
                 <td role="cell">{{ rule.rationale }}</td>
             </tr>
             {% endif %}
             {% if rule.warnings %}
             <tr role="row">
-                <td role="cell">Warnings:</td>
+                <td role="cell"><b>Warnings:</b></td>
                 <td role="cell">
                     {% for warning in rule.warnings %}
                     <div class="pf-c-alert pf-m-warning pf-m-inline">

--- a/oscap_report/html_report/templates/rule_detail.html
+++ b/oscap_report/html_report/templates/rule_detail.html
@@ -136,8 +136,18 @@
             {% endif %}
             {% if rule.message != "" %}
             <tr role="row">
-                <td role="cell">Message:</td>
-                <td role="cell">{{ rule.message }}</td>
+                <td role="cell"><b>Message:</b></td>
+                <td role="cell">
+                    <div class="pf-c-alert pf-m-info pf-m-inline">
+                        <div class="pf-c-alert__icon">
+                            <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                        </div>
+                        <p class="pf-c-alert__title">
+                            <span class="pf-screen-reader">Message:</span>
+                            {{ rule.message }}
+                        </p>
+                    </div>
+                </td>
             </tr>
             {% endif %}
             {% include "remedations.html" %}

--- a/oscap_report/html_report/templates/rule_results.html
+++ b/oscap_report/html_report/templates/rule_results.html
@@ -1,4 +1,4 @@
-<div class="progress" style="height: 20px;">
+<div class="progress">
     {% if 0 != rule_result_stats.pass %}
     <div class="progress-bar" role="progressbar" style="width:{{ rule_result_stats.pass_percent }}%;background-color: #3E8635;">{{ rule_result_stats.pass }} Pass
     </div>

--- a/oscap_report/html_report/templates/rules_overview.html
+++ b/oscap_report/html_report/templates/rules_overview.html
@@ -1,4 +1,4 @@
-<input class="pf-c-form-control pf-m-search" type="search" placeholder="Search rule" id="input-search-rule" />
+<input class="pf-c-form-control pf-m-search" title="Submit with enter!" type="search" placeholder="Search rule" id="input-search-rule" />
 <br>
 <br>
 <table class="pf-c-table pf-m-expandable pf-m-grid-lg" role="grid" id="rule-table">

--- a/oscap_report/html_report/templates/severity_of_failed_rules.html
+++ b/oscap_report/html_report/templates/severity_of_failed_rules.html
@@ -1,15 +1,15 @@
 {% set severity_of_failed_rules = report.get_severity_of_failed_rules_stats() %}
-<div class="progress" style="height: 20px;">
+<div class="progress">
     {% if 0 !=  severity_of_failed_rules.unknown %}
-        <div class="progress-bar pf-m-success" role="progressbar" style="width:{{ severity_of_failed_rules.unknown_percent }}%;background-color: #6A6E73;">{{ severity_of_failed_rules.unknown }} Unknown</div>
+        <div class="progress-bar" role="progressbar" style="width:{{ severity_of_failed_rules.unknown_percent }}%;background-color: #6A6E73;">{{ severity_of_failed_rules.unknown }} Unknown</div>
     {% endif %}
     {% if 0 !=  severity_of_failed_rules.low %}
-        <div class="progress-bar pf-m-info" role="progressbar" style="width:{{ severity_of_failed_rules.low_percent }}%;background-color: #73C5C5;">{{ severity_of_failed_rules.low }} Low</div>
+        <div class="progress-bar" role="progressbar" style="width:{{ severity_of_failed_rules.low_percent }}%;background-color: #73C5C5;">{{ severity_of_failed_rules.low }} Low</div>
     {% endif %}
     {% if 0 !=  severity_of_failed_rules.medium %}
         <div class="progress-bar" role="progressbar" style="width:{{ severity_of_failed_rules.medium_percent }}%;background-color: #F0AB00;">{{ severity_of_failed_rules.medium }} Medium</div>
     {% endif %}
     {% if 0 !=  severity_of_failed_rules.high %}
-        <div class="progress-bar pf-m-danger" role="progressbar" style="width:{{ severity_of_failed_rules.high_percent }}%;background-color: #C9190B;">{{ severity_of_failed_rules.high }} High</div>
+        <div class="progress-bar" role="progressbar" style="width:{{ severity_of_failed_rules.high_percent }}%;background-color: #C9190B;">{{ severity_of_failed_rules.high }} High</div>
     {% endif %}
 </div>


### PR DESCRIPTION
This PR changes small detail in the HTML report:
- Search of the rule is executed by pressing enter
- Bold text in tables
- Message in the rule is not only text anymore 
- Removed bootstrap and using own CSS for progress bars