### PR TITLE
Fix jquery search by IDs

### DIFF
--- a/oscap_report/html_report/templates/js/interactive_script.js
+++ b/oscap_report/html_report/templates/js/interactive_script.js
@@ -127,7 +127,7 @@ function render_OVAL_test(node) {
             '<\/span>' +
         '<\/span>' +
     '<\/span>'; // End span
-    var info_id = 'info_of_test_' + test_id;
+    var info_id = 'info_of_test_' + test_id.replace(/[\.:_\-]/ug, "");
     tree_content +=
         '<button ' +
             'class="pf-c-button pf-m-inline pf-m-link" onClick="show_OVAL_details($(this), \'div #' + info_id + '\');" ' +


### PR DESCRIPTION
This PR fixes problems with jquery searching IDs containing unexpected characters like `.-_:`.

This problem you can invoke with a test file `tests/test_data/arf_simple_rule_pass.xml` and pressing on show test details in the oval graph.